### PR TITLE
S003: Added gradient support for progress line in AdaptiveSlider

### DIFF
--- a/Sources/AdaptiveSlider/Protocols/AdaptiveSlider.swift
+++ b/Sources/AdaptiveSlider/Protocols/AdaptiveSlider.swift
@@ -1,5 +1,17 @@
 import SwiftUI
 
+/// A type alias representing a flexible style for filling a shape.
+///
+/// `AdaptiveStyle` can be used for colors, gradients, or other fill styles.
+/// This typealias makes it easier to apply either solid colors or gradients (e.g., `LinearGradient`, `RadialGradient`, `AngularGradient`)
+/// to views, enhancing the versatility of UI components like sliders.
+///
+/// Example usage:
+/// ```swift
+/// let style: AdaptiveStyle = LinearGradient(colors: [.red, .blue], startPoint: .leading, endPoint: .trailing)
+/// ```
+public typealias AdaptiveStyle = (any ShapeStyle)
+
 // MARK: - AdaptiveSlider Protocol
 
 /// A protocol defining the behaviour of adaptive sliders.
@@ -18,7 +30,7 @@ public protocol AdaptiveSlider: View {
 
 	// Track Properties
 	var trackColor: Color { get set }
-	var progressColor: Color { get set }
+	var progressColor: AdaptiveStyle? { get set }
 	var lineWidth: CGFloat { get set }
 
 	// Optional Ticks

--- a/Sources/AdaptiveSlider/Utilities/Extensions/PackageExtentions/AdaptiveSlider+Ext.swift
+++ b/Sources/AdaptiveSlider/Utilities/Extensions/PackageExtentions/AdaptiveSlider+Ext.swift
@@ -9,6 +9,16 @@ public extension AdaptiveSlider {
 	}
 }
 
+extension AdaptiveSlider {
+	var progressFill: AnyShapeStyle {
+		if let progressColor {
+			return AnyShapeStyle(progressColor)
+		} else  {
+			return AnyShapeStyle(Color(.systemBlue))
+		}
+	}
+}
+
 public extension AdaptiveSlider {
 	func trackStyle(lineWidth: CGFloat, color: Color = Color(.systemGray5)) -> Self {
 		var copy = self

--- a/Sources/AdaptiveSlider/Utilities/Extensions/PackageExtentions/AdaptiveSlider+Ext.swift
+++ b/Sources/AdaptiveSlider/Utilities/Extensions/PackageExtentions/AdaptiveSlider+Ext.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 public extension AdaptiveSlider {
-	func tint(_ tint: Color?) -> Self {
+	func tint(_ tint: AdaptiveStyle?) -> Self {
 		guard let tint else { return self }
 		var copy = self
 		copy.progressColor = tint

--- a/Sources/AdaptiveSlider/Views/CircularSlider.swift
+++ b/Sources/AdaptiveSlider/Views/CircularSlider.swift
@@ -78,7 +78,7 @@ public struct CircularSlider<Value: BinaryFloatingPoint, Label: View>: CircularS
 			Circle()
 				.trim(from: 0.0, to: CGFloat(percentage(ofValue: value.wrappedValue)))
 				.stroke(style: StrokeStyle(lineWidth: lineWidth, lineCap: .round, lineJoin: .round))
-				.foregroundColor(progressColor)
+				.foregroundStyle(progressFill)
 				.frame(width: radius * 2, height: radius * 2)
 				.rotationEffect(.degrees(-90))
 

--- a/Sources/AdaptiveSlider/Views/CircularSlider.swift
+++ b/Sources/AdaptiveSlider/Views/CircularSlider.swift
@@ -18,7 +18,7 @@ public struct CircularSlider<Value: BinaryFloatingPoint, Label: View>: CircularS
 	public var thumbRadius: CGFloat = 11
 	public var thumbColor: Color = .white
 	public var trackColor: Color = Color(.systemGray5)
-	public var progressColor: Color = Color(.systemBlue)
+	public var progressColor: AdaptiveStyle?
 	public var lineWidth: CGFloat = 5
 	public var showTicks: Bool = false
 	public var tickCount: Int = 0
@@ -193,11 +193,17 @@ struct PreviewCircularSlider: View {
 		VStack(spacing: 40) {
 			CircularSlider(
 				value: $sliderValue1,
-				in: 0...100,
-				step: 10) {
+				in: 0...100) {
 					Text("\(Int(sliderValue1))")
 				}
-				.showTicks(count: 6)
+				.tint(
+					LinearGradient(
+						colors: [.red, .orange, .yellow],
+						startPoint: .top,
+						endPoint: .bottom
+					)
+				)
+//				.showTicks(count: 6)
 			
 			CircularSlider(
 				value: $sliderValue2,


### PR DESCRIPTION
### Summery of changes

- Created `AdaptiveStyle` typealias which is (any ShapeStyle)
- Updated the progressColor type to `AdaptiveStyle` (optional)
- Update the tint modifier to accept a parameter of type `AdaptiveStyle` this way we can use the existing tint modifier in order to set gradients to the progress line.

### Prerequisites

- [x] Did check Swiftlint for new warnings and errors

### Screenshots

| Before | After |
| ------ | ----- |
| ![Nov-21-2024 23-53-37](https://github.com/user-attachments/assets/23f3c966-c138-491b-a301-38567e01dc10) | ![Nov-21-2024 23-53-46](https://github.com/user-attachments/assets/57b18214-569b-435f-b49e-e9d3cf00efa9) |
