### PR TITLE
S004: Enable complete concurrency checking

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,9 +18,17 @@ let package = Package(
         // Targets are the basic building blocks of a package, defining a module or a test suite.
         // Targets can depend on other targets in this package and products from dependencies.
         .target(
-            name: "AdaptiveSlider"),
+            name: "AdaptiveSlider",
+			swiftSettings: [
+				.enableUpcomingFeature("StrictConcurrency")
+			  ]
+		),
         .testTarget(
             name: "AdaptiveSliderTests",
-            dependencies: ["AdaptiveSlider"])
+            dependencies: ["AdaptiveSlider"],
+			swiftSettings: [
+				.enableUpcomingFeature("StrictConcurrency")
+			  ]
+		)
     ]
 )

--- a/Sources/AdaptiveSlider/Protocols/AdaptiveSlider.swift
+++ b/Sources/AdaptiveSlider/Protocols/AdaptiveSlider.swift
@@ -15,6 +15,7 @@ public typealias AdaptiveStyle = (any ShapeStyle)
 // MARK: - AdaptiveSlider Protocol
 
 /// A protocol defining the behaviour of adaptive sliders.
+@MainActor
 public protocol AdaptiveSlider: View {
 	associatedtype Value: BinaryFloatingPoint where Value.Stride: BinaryFloatingPoint
 	associatedtype Label: View


### PR DESCRIPTION

This PR enables strict concurrency checking to prepare for the upcoming Swift 6 concurrency model and to enhance data race safety across the `AdaptiveSlider` library.

### Summery of changes

- Updated the Swift package manifest to enable strict concurrency using `.enableUpcomingFeature("StrictConcurrency")`.
- Annotated `AdaptiveSlider` protocol with `@MainActor` to ensure UI-related code runs on the main thread, enhancing data race safety.


