### PR TITLE
S006: Add Platform-Specific Support for Haptic Feedback and Default Colors

### DIFF
--- a/Sources/AdaptiveSlider/Protocols/AdaptiveSlider.swift
+++ b/Sources/AdaptiveSlider/Protocols/AdaptiveSlider.swift
@@ -40,8 +40,10 @@ public protocol AdaptiveSlider: View {
 	var tickSize: CGSize { get set }
 	var tickColor: Color { get set }
 
+#if os(iOS)
 	/// Optional feedback generator for haptics
 	var feedbackGenerator: UIImpactFeedbackGenerator? { get set }
+#endif
 
 	// Accessibility properties
 

--- a/Sources/AdaptiveSlider/Utilities/Extensions/PackageExtentions/AdaptiveSlider+Ext.swift
+++ b/Sources/AdaptiveSlider/Utilities/Extensions/PackageExtentions/AdaptiveSlider+Ext.swift
@@ -20,10 +20,14 @@ extension AdaptiveSlider {
 }
 
 public extension AdaptiveSlider {
-	func trackStyle(lineWidth: CGFloat, color: Color = Color(.systemGray5)) -> Self {
+	func trackStyle(lineWidth: CGFloat, color: Color? = nil) -> Self {
 		var copy = self
 		copy.lineWidth = lineWidth
-		copy.trackColor = color
+#if os(iOS)
+		copy.trackColor = color ?? Color(.systemGray5)
+#else
+		copy.trackColor = color ?? Color.gray
+#endif
 		return copy
 	}
 }
@@ -41,13 +45,17 @@ public extension AdaptiveSlider {
 	func showTicks(
 		count: Int,
 		size: CGSize? = nil,
-		color: Color = Color(.systemGray2)
+		color: Color? = nil
 	) -> Self {
 		var copy = self
 		copy.showTicks = true
 		copy.tickCount = count
 		copy.tickSize = size ?? CGSize(width: 1.5, height: lineWidth)
-		copy.tickColor = color
+#if os(iOS)
+		copy.tickColor = color ?? Color(.systemGray2)
+#else
+		copy.tickColor = color ?? Color.gray
+#endif
 		return copy
 	}
 }

--- a/Sources/AdaptiveSlider/Utilities/Extensions/PackageExtentions/AdaptiveSlider+Ext.swift
+++ b/Sources/AdaptiveSlider/Utilities/Extensions/PackageExtentions/AdaptiveSlider+Ext.swift
@@ -52,6 +52,7 @@ public extension AdaptiveSlider {
 	}
 }
 
+#if os(iOS)
 public extension AdaptiveSlider {
 	func hapticFeedback(_ style: UIImpactFeedbackGenerator.FeedbackStyle) -> Self {
 		var copy = self
@@ -59,6 +60,7 @@ public extension AdaptiveSlider {
 		return copy
 	}
 }
+#endif
 
 public extension AdaptiveSlider {
 	/// Enables customization of the accessibility **Value**, **Hint**, and **Label** for `AdaptiveSlider`.

--- a/Sources/AdaptiveSlider/Views/CircularSlider.swift
+++ b/Sources/AdaptiveSlider/Views/CircularSlider.swift
@@ -24,10 +24,13 @@ public struct CircularSlider<Value: BinaryFloatingPoint, Label: View>: CircularS
 	public var tickCount: Int = 0
 	public var tickSize: CGSize = .zero
 	public var tickColor: Color = .clear
-	public var feedbackGenerator: UIImpactFeedbackGenerator?
 	public var accessibilityLabel: String = ""
 	public var accessibilityValue: String = ""
 	public var accessibilityHint: String = ""
+
+#if os(iOS)
+	public var feedbackGenerator: UIImpactFeedbackGenerator?
+#endif
 
 	private var angle: Double {
 		angleDegrees(forValue: value.wrappedValue)
@@ -104,7 +107,9 @@ public struct CircularSlider<Value: BinaryFloatingPoint, Label: View>: CircularS
 		.accessibilityValue(accessibilityValue)
 		.accessibilityAdjustableAction(adjustValue(for:))
 		.onAppear {
+#if os(iOS)
 			feedbackGenerator?.prepare()
+#endif
 		}
 	}
 
@@ -119,7 +124,9 @@ public struct CircularSlider<Value: BinaryFloatingPoint, Label: View>: CircularS
 
 		if shouldUpdateValue(to: snappedValue) {
 			value.wrappedValue = snappedValue
+#if os(iOS)
 			feedbackGenerator?.impactOccurred()
+#endif
 		}
 	}
 

--- a/Sources/AdaptiveSlider/Views/CircularSlider.swift
+++ b/Sources/AdaptiveSlider/Views/CircularSlider.swift
@@ -17,7 +17,13 @@ public struct CircularSlider<Value: BinaryFloatingPoint, Label: View>: CircularS
 	public var radius: CGFloat = 100
 	public var thumbRadius: CGFloat = 11
 	public var thumbColor: Color = .white
+
+#if os(iOS)
 	public var trackColor: Color = Color(.systemGray5)
+#else
+	public var trackColor: Color = Color.gray
+#endif
+
 	public var progressColor: AdaptiveStyle?
 	public var lineWidth: CGFloat = 5
 	public var showTicks: Bool = false


### PR DESCRIPTION
### Summery of changes

- Added conditional compilation (#if os(...)) to set appropriate default colors for properties such as trackColor and tickColor.
    - On iOS, systemGray colors are used, while other platforms use Color.gray.
- Introduced platform-specific check for the feedbackGenerator property, ensuring it is available only on iOS to avoid issues on platforms without haptic support.

