### PR TITLE
S008: Add `AdaptiveSliderPreviews` target for SwiftUI previews

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,6 +23,15 @@ let package = Package(
 				.enableUpcomingFeature("StrictConcurrency")
 			  ]
 		),
+		.target(
+			name: "AdaptiveSliderPreviews",
+			dependencies: ["AdaptiveSlider"],
+			path: "Sources/AdaptiveSliderPreviews",
+			swiftSettings: [
+				.define("DEBUG"),
+				.enableUpcomingFeature("StrictConcurrency")
+			  ]
+		),
         .testTarget(
             name: "AdaptiveSliderTests",
             dependencies: ["AdaptiveSlider"],

--- a/Sources/AdaptiveSlider/Views/CircularSlider.swift
+++ b/Sources/AdaptiveSlider/Views/CircularSlider.swift
@@ -198,38 +198,3 @@ public struct CircularSlider<Value: BinaryFloatingPoint, Label: View>: CircularS
 		}
 	}
 }
-
-struct PreviewCircularSlider: View {
-	@State private var sliderValue1: Double = 40
-	@State private var sliderValue2: Double = 40
-	var body: some View {
-		VStack(spacing: 40) {
-			CircularSlider(
-				value: $sliderValue1,
-				in: 0...100) {
-					Text("\(Int(sliderValue1))")
-				}
-				.tint(
-					LinearGradient(
-						colors: [.red, .orange, .yellow],
-						startPoint: .top,
-						endPoint: .bottom
-					)
-				)
-//				.showTicks(count: 6)
-			
-			CircularSlider(
-				value: $sliderValue2,
-				in: 0...100) {
-					Text("\(Int(sliderValue2))")
-				}
-				.tint(.red)
-				.trackStyle(lineWidth: 10, color: .green)
-				.showTicks(count: 100, color: .yellow)
-		}
-	}
-}
-
-#Preview {
-	PreviewCircularSlider()
-}

--- a/Sources/AdaptiveSliderPreviews/CircularSliderPreview.swift
+++ b/Sources/AdaptiveSliderPreviews/CircularSliderPreview.swift
@@ -1,0 +1,56 @@
+//
+//  SwiftUIView.swift
+//  AdaptiveSlider
+//
+//  Created by John Kousherian on 2024-12-12.
+//
+
+import SwiftUI
+import AdaptiveSlider
+
+/// NOTE: To display this preview in Xcode:
+/// 1. Ensure the `AdaptiveSliderPreviews` target is included as a dependency in the `Package.swift` manifest file.
+/// 2. Add `AdaptiveSliderPreviews` to the `products` section of your package manifest temporarily.
+///    Example:
+///    ```
+///    .library(
+///        name: "AdaptiveSlider",
+///        targets: ["AdaptiveSlider", "AdaptiveSliderPreviews"]
+///    )
+///    ```
+/// 3. Ensure the preview file is part of the `AdaptiveSliderPreviews` target under Target Membership.
+/// 4. After testing, you can remove `AdaptiveSliderPreviews` from the `products` section to avoid shipping it in production.
+private struct CircularSliderPreviewView: View {
+	@State private var sliderValue1: Double = 25
+	@State private var sliderValue2: Double = 60
+
+	var body: some View {
+		VStack(spacing: 40) {
+			CircularSlider(
+				value: $sliderValue1,
+				in: 0...100) {
+					Text("\(Int(sliderValue1))")
+				}
+				.tint(
+					LinearGradient(
+						colors: [.red, .orange, .yellow],
+						startPoint: .top,
+						endPoint: .bottom
+					)
+				)
+
+			CircularSlider(
+				value: $sliderValue2,
+				in: 0...100) {
+					Text("\(Int(sliderValue2))")
+				}
+				.tint(.red)
+				.trackStyle(lineWidth: 10, color: .green)
+				.showTicks(count: 100, color: .yellow)
+		}
+	}
+}
+
+#Preview {
+	CircularSliderPreviewView()
+}


### PR DESCRIPTION
### Summery of changes

- Created a dedicated `AdaptiveSliderPreviews` target for testing and previewing sliders.
- Added a separate `CircularSliderPreview` for showcasing and iterating on `CircularSlider` designs.
- Updated the `Package.swift` manifest to include the `AdaptiveSliderPreviews` target.
- Provided detailed notes in the preview struct to guide developers on enabling previews in Xcode.
- Ensured the target does not ship with production builds by keeping it excluded from the main product.

### Prerequisites

- [ ] Did check Swiftlint for new warnings and errors
- [ ] Did run a successful test on last commit

### Screenshots

N/A
